### PR TITLE
feat: post_list 구성 및 개발 환경 정리

### DIFF
--- a/comment_form.html
+++ b/comment_form.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
-    <link rel="stylesheet" href="static/css/bootstrap/bootstrap.min.css" media="screen">
-    <link rel="stylesheet" href="static/css/comment_form.css" media="screen">
+    <link rel="stylesheet" href="static/css/styles.css" media="screen">
     <script src="https://kit.fontawesome.com/726bbd6862.js" crossorigin="anonymous"></script>
 </head>
 <body>

--- a/home.html
+++ b/home.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
-    <link rel="stylesheet" href="static/css/bootstrap/bootstrap.min.css" media="screen">
-    <link rel="stylesheet" href="static/css/home.css" media="screen">
+    <link rel="stylesheet" href="static/css/styles.css" media="screen">
 </head>
 <body>
     <div include-html="reference/navbar.html"></div>

--- a/login.html
+++ b/login.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
-    <link rel="stylesheet" href="static/css/bootstrap/bootstrap.min.css" media="screen">
-    <link rel="stylesheet" href="static/css/login.css" media="screen">
+    <link rel="stylesheet" href="static/css/styles.css" media="screen">
     <script src="https://kit.fontawesome.com/726bbd6862.js" crossorigin="anonymous"></script>
 </head>
 <body>

--- a/post_detail.html
+++ b/post_detail.html
@@ -3,9 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Bootstrap demo</title>
-    <link rel="stylesheet" href="static/css/bootstrap/bootstrap.min.css" media="screen">
-    <link rel="stylesheet" href="static/css/post_detail.css" media="screen">
+    <title>상명대학교 - 청원게시판</title>
+    <link rel="stylesheet" href="static/css/styles.css" media="screen">
     <script src="https://kit.fontawesome.com/726bbd6862.js" crossorigin="anonymous"></script>
 </head>
 <body>

--- a/post_form.html
+++ b/post_form.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
-    <link rel="stylesheet" href="static/css/bootstrap/bootstrap.min.css" media="screen">
-    <link rel="stylesheet" href="static/css/post_form.css" media="screen">
+    <link rel="stylesheet" href="static/css/styles.css" media="screen">
     <script src="https://kit.fontawesome.com/726bbd6862.js" crossorigin="anonymous"></script>
 </head>
 <body>

--- a/post_list.html
+++ b/post_list.html
@@ -39,7 +39,7 @@
             <tbody class="table-body">
                 <tr include-html="sample/post_data.html"></tr>
                 <tr class="text-center table-sangmyung__body">
-                    <td>
+                    <td class="table-body__number">
                         <span class="table-body__notice-icon">공지</span>
                     </td>
                     <td class="table-body__proceeding">[진행중]</td>
@@ -54,7 +54,7 @@
                         <i class="far fa-comment table-body__icon"></i>0</td>
                 </tr>
                 <tr class="text-center table-sangmyung__body">
-                    <td>
+                    <td class="table-body__number">
                         2
                     </td>
                     <td class="table-body__complete">[답변완료]</td>
@@ -69,7 +69,7 @@
                         <i class="far fa-comment table-body__icon"></i>0</td>
                 </tr>
                 <tr class="text-center table-sangmyung__body">
-                    <td>
+                    <td class="table-body__number">
                         1
                     </td>
                     <td class="table-body__proceeding">[진행중]</td>

--- a/post_list.html
+++ b/post_list.html
@@ -68,6 +68,22 @@
                     <td class="table-body__comment">
                         <i class="far fa-comment table-body__icon"></i>0</td>
                 </tr>
+                <tr class="text-center table-sangmyung__body">
+                    <td>
+                        1
+                    </td>
+                    <td class="table-body__proceeding">[진행중]</td>
+                    <td class="text-start">
+                        <span class="table-body__new">N</span>
+                        <a href="{% url 'pybo:detail' question.id %}">스뮤니티 화이팅</a>
+                    </td>
+                    <td>익명</td>
+                    <td class="table-body__like">
+                        <i class="far fa-thumbs-up table-body__icon"></i>999+
+                    </td>
+                    <td class="table-body__comment">
+                        <i class="far fa-comment table-body__icon"></i>999+</td>
+                </tr>
             </tbody>
         </table>
         <div include-html="reference/pagination.html"></div>

--- a/post_list.html
+++ b/post_list.html
@@ -3,9 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Bootstrap demo</title>
-    <link rel="stylesheet" href="static/css/bootstrap/bootstrap.min.css" media="screen">
-    <link rel="stylesheet" href="static/css/post_list.css" media="screen">
+    <title>상명대학교 - 청원게시판</title>
+    <link rel="stylesheet" href="static/css/styles.css" media="screen">
     <script src="https://kit.fontawesome.com/726bbd6862.js" crossorigin="anonymous"></script>
 </head>
 <body>
@@ -27,25 +26,48 @@
             </div>
         </div>
         <table class="table">
-            <thead>
-            <tr class="text-center table-dark">
+            <thead class="table-head">
+            <tr class="text-center table-sangmyung__header">
                 <th>번호</th>
+                <th>말머리</th>
                 <th style="width:50%">제목</th>
                 <th>글쓴이</th>
-                <th>작성일시</th>
+                <th>추천</th>
+                <th>댓글</th>
             </tr>
             </thead>
-            <tbody>
+            <tbody class="table-body">
                 <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
-                <tr include-html="sample/post_data.html"></tr>
+                <tr class="text-center table-sangmyung__body">
+                    <td>
+                        <span class="table-body__notice-icon">공지</span>
+                    </td>
+                    <td class="table-body__proceeding">[진행중]</td>
+                    <td class="text-start table-body__notice">
+                        <a href="{% url 'pybo:detail' question.id %}">청원게시판 소개</a>
+                    </td>
+                    <td>익명</td>
+                    <td class="table-body__like">
+                        <i class="far fa-thumbs-up table-body__icon"></i>9
+                    </td>
+                    <td class="table-body__comment">
+                        <i class="far fa-comment table-body__icon"></i>0</td>
+                </tr>
+                <tr class="text-center table-sangmyung__body">
+                    <td>
+                        2
+                    </td>
+                    <td class="table-body__complete">[답변완료]</td>
+                    <td class="text-start">
+                        <a href="{% url 'pybo:detail' question.id %}">공학인증제도 수정</a>
+                    </td>
+                    <td>익명</td>
+                    <td class="table-body__like">
+                        <i class="far fa-thumbs-up table-body__icon"></i>9
+                    </td>
+                    <td class="table-body__comment">
+                        <i class="far fa-comment table-body__icon"></i>0</td>
+                </tr>
             </tbody>
         </table>
         <div include-html="reference/pagination.html"></div>

--- a/sample/post_data.html
+++ b/sample/post_data.html
@@ -1,12 +1,14 @@
 <!-- 샘플 청원 데이터 -->
-<tr class="text-center">
+<tr class="text-center table-sangmyung">
     <td>
         1
     </td>
+    <td>[진행중]</td>
     <td class="text-start">
         <a href="{% url 'pybo:detail' question.id %}">공학인증제도 수정</a>
         <span class="text-danger small mx-2">60</span>
     </td>
     <td>익명</td>
-    <td>23.01.10</td>
+    <td>9</td>
+    <td>0</td>
 </tr>

--- a/signup.html
+++ b/signup.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
-    <link rel="stylesheet" href="static/css/bootstrap/bootstrap.min.css" media="screen">
-    <link rel="stylesheet" href="static/css/signup.css" media="screen">
+    <link rel="stylesheet" href="static/css/styles.css" media="screen">
     <script src="https://kit.fontawesome.com/726bbd6862.js" crossorigin="anonymous"></script>
 </head>
 <body>

--- a/static/css/post_list.css
+++ b/static/css/post_list.css
@@ -1,0 +1,52 @@
+.table-sangmyung__header {
+    background-color: white;
+    color: black;
+    border-top: 1px solid var(--sangmyung);
+    text-decoration: none;
+}
+
+.table-sangmyung__body {
+    background-color: white;
+    transition: all 0.3s ease-in-out;
+}
+
+.table-sangmyung__body:hover {
+    background-color: rgb(225, 228, 239);
+}
+
+.table-body__notice-icon {
+    font-size: 12px;
+    color: white;
+    background-color: rgb(252, 98, 8);
+    padding: 3px 10px;
+    border-radius: 5px;
+}
+
+.table-body__notice {
+    font-weight: 600;
+}
+
+.table-body__icon {
+    margin-right: 5px;
+}
+
+.table-body__like {
+    color: rgb(252, 52, 61);
+}
+
+.table-body__comment {
+    color: rgb(59, 111, 173);
+}
+
+.text-start a {
+    text-decoration: none;
+    color: black;
+}
+
+.table-body__proceeding {
+    color: rgb(42, 80, 135);
+}
+
+.table-body__complete {
+    color: rgb(191, 72, 84);
+}

--- a/static/css/post_list.css
+++ b/static/css/post_list.css
@@ -50,3 +50,18 @@
 .table-body__complete {
     color: rgb(191, 72, 84);
 }
+
+.text-start {
+    display: flex;
+    align-items: center;
+}
+
+.table-body__new {
+    font-size: 11px;
+    margin-right: 5px;
+    font-weight: 900;
+    color: white;
+    background-color: rgb(43, 143, 239);
+    padding: 1px 3px;
+    border-radius: 3px;
+}

--- a/static/css/post_list.css
+++ b/static/css/post_list.css
@@ -5,7 +5,12 @@
     text-decoration: none;
 }
 
+.text-center {
+    display: table-row;
+}
+
 .table-sangmyung__body {
+    display: table-row;
     background-color: white;
     transition: all 0.3s ease-in-out;
 }
@@ -64,4 +69,14 @@
     background-color: rgb(43, 143, 239);
     padding: 1px 3px;
     border-radius: 3px;
+}
+
+td:not(:first-child) {
+    padding-top: 17px;
+    padding-bottom: 17px;
+}
+
+td:first-child {
+    padding-top: 17px;
+    padding-bottom: 17px;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,24 @@
+/* Nanum Gothic - Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&family=Ubuntu:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap');
+
+/* bootstrap */
+@import "bootstrap/bootstrap.min.css";
+
+/* Screens */
+@import "home.css";
+@import "login.css";
+@import "signup.css";
+@import "post_detail.css";
+@import "post_form.css";
+@import "post_list.css";
+@import "comment_form.css";
+
+/* Variables */
+@import "variables.css";
+
+/* Components */
+
+
+body {
+    font-family: 'Nanum Gothic', sans-serif;
+}

--- a/static/css/variables.css
+++ b/static/css/variables.css
@@ -1,0 +1,3 @@
+:root {
+    --sangmyung: rgb(1, 42, 127);
+}


### PR DESCRIPTION
post_list.html / post_list.css 구성 완료 했습니다.
또한 개발 환경도 조금 더 정리했어요.
내용 발표는 내일 하겠습니다.

post_list 까지 하고 잠시 멈췄는데요, 사유는 이것저것 통일하고 정해야할 규칙이 있어야 할 것 같아서 입니다..
아래 적힌 내용이 통일 되면 나머지 빠르게 구성해보도록 할게요.

개발 환경을 조금 더 정리 했는데, 내일 프론트 회의때 어떻게 정리했는지 발표할게요.
CSS 파일이 흩어져 있는것을 개인적으로 선호하지 않아서, 
styles.css 파일을 만들고 거기에 한번에 import 후, html 파일에 styles.css 파일만 link 했습니다.
혹시 기존 방법이 더 편하면 그걸로 가면 될 것 같습니다.

class 이름 짓는것도 통일해야 할 것 같아요.
BEM 네이밍으로 통일하면 좋을 것 같습니다. 현업에서도 BEM 네이밍 많이 사용하니까요 !
참고 링크 : https://velog.io/@nemo/bem

구성 내용 -
게시판 구성 (nav_bar, footer 자리 제외)
-> tbody에 hover transition 설정 등
변수 설정 (학교 색 (--sangmyung))
글꼴 설정 (구글 폰트 - 나눔고딕)

Q. 왜 include-html이 작동하지 않을까요? 그냥 tr 태그를 가져와서 붙이는 식으로 해결하긴 했습니다만..

!. Bootstrap 덕분에 테이블의 body 가 display: table-row 의 속성을 가지는데요, 이 display 속성은 padding을 가질 수 없더라구요. tr 안에 있는 td elements에 padding을 주는 식으로 우회하면 padding 적용이 가능합니다. 단, td의 first-child에는 예외를 줘야 해요. 따로 적용해야합니다. 왜 그런지는 아직 모르겠어요,..
https://stackoverflow.com/questions/3656615/padding-a-table-row


https://user-images.githubusercontent.com/61226778/212703876-da907088-398c-4688-b362-a60230a97d2b.mov




